### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/firescry/zephyr
+
+go 1.14


### PR DESCRIPTION
go.mod is required to build _zephyr_ without problems.